### PR TITLE
Fixed autocomplete formatting

### DIFF
--- a/sublime-text-merlin.py
+++ b/sublime-text-merlin.py
@@ -364,7 +364,12 @@ class Autocomplete(sublime_plugin.EventListener):
             self.cplns_ready = False
             line, col = view.rowcol(locations[0])
             result = process.complete_cursor(prefix, line + 1, col)
-            self.cplns = [(clean_whitespace(r['name'] + '\t' + r['desc']), r['name']) for r in result['entries']]
+
+            self.cplns = []
+            for r in result['entries']:
+                name = clean_whitespace(r['name'])
+                desc = clean_whitespace(r['desc'])
+                self.cplns.append(((name + '\t' + desc), name))
 
             self.show_completions(view, self.cplns)
 


### PR DESCRIPTION
Looks like the `\t` symbol is removed by `clean_whitespace`...

Before:

<img width="585" alt="screen shot 2015-09-01 at 9 21 04 pm" src="https://cloud.githubusercontent.com/assets/192222/9639429/dbe5de9e-5160-11e5-9000-f38fd92ebcf5.png">

After:

<img width="573" alt="screen shot 2015-09-01 at 9 20 50 pm" src="https://cloud.githubusercontent.com/assets/192222/9639449/e1204386-5160-11e5-9277-b60e79c49bbe.png">
