### PR TITLE
RFC: Insert snippet when autocompleting functions

### DIFF
--- a/merlin/helpers.py
+++ b/merlin/helpers.py
@@ -65,3 +65,22 @@ def clean_whitespace(text):
     """
 
     return ' '.join(text.split())
+
+
+def make_snippet(name, desc):
+    """
+    Converts name and desc provided by merlin autocomplete to
+    a Sublime Text snippet
+    """
+    snippet = name
+
+    # TODO: Need a better way of splitting params, "->"
+    # can appear inside function type args, e.g. in List.map
+    args = []
+    for idx, name in enumerate(desc.split(' -> ')[:-1]):
+        args.append('${%s:%s}' % (idx + 1, name))
+
+    if args:
+        snippet += ' ' + ' '.join(args)
+
+    return snippet

--- a/sublime-text-merlin.py
+++ b/sublime-text-merlin.py
@@ -12,10 +12,10 @@ import sys
 
 if sys.version_info < (3, 0):
     from merlin.process import MerlinProcess
-    from merlin.helpers import merlin_pos, only_ocaml, clean_whitespace
+    from merlin.helpers import merlin_pos, only_ocaml, clean_whitespace, make_snippet
 else:
     from .merlin.process import MerlinProcess
-    from .merlin.helpers import merlin_pos, only_ocaml, clean_whitespace
+    from .merlin.helpers import merlin_pos, only_ocaml, clean_whitespace, make_snippet
 
 running_process = None
 
@@ -369,7 +369,7 @@ class Autocomplete(sublime_plugin.EventListener):
             for r in result['entries']:
                 name = clean_whitespace(r['name'])
                 desc = clean_whitespace(r['desc'])
-                self.cplns.append(((name + '\t' + desc), name))
+                self.cplns.append(((name + '\t' + desc), make_snippet(name, desc)))
 
             self.show_completions(view, self.cplns)
 


### PR DESCRIPTION
This is work in progress, just wanted to get some inputs on if that's valuable at all. The idea is to insert a Sublime Text snippet when users select autocomplete option. This lets them use `Tab` to jump over suggested arguments placeholders.

![Demo](https://cloud.githubusercontent.com/assets/192222/9700478/6f63f4bc-53b9-11e5-82c0-c14d9523bfb9.gif)
